### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ XML Attributes
 Installation
 -------
 ```
-compile 'io.saeid:fab-loading:1.0.0'
+implementation 'io.saeid:fab-loading:1.0.0'
 ```
 
 Credits


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.